### PR TITLE
fix: idx parsing

### DIFF
--- a/tools/lib/idxfile.py
+++ b/tools/lib/idxfile.py
@@ -24,7 +24,7 @@ class IdxFile:
         self.segments = self.segments(
             buf=file_data[SMPK_SIZE:SMPK_SIZE+STRUCT_SIZE])
         self.records = self.records(
-            buf=file_data[SMPK_SIZE+STRUCT_SIZE:self.segments[1]["size"]]
+            buf=file_data[SMPK_SIZE+STRUCT_SIZE:SMPK_SIZE+STRUCT_SIZE+self.segments[1]["size"]]
         )
 
     def smpk(self, buf):


### PR DESCRIPTION
As we're parsing the entire buffer in memory and chopping it up into segments based on the length of the bytes, need to add the length of the beginning of the buffer size to the other end when filtering.

This wasn't noticed for big files like in `Game\Content\Data` (because the end of these files have a bunch of folder names in them), but was noticed in much smaller files like in `Game\Content\Ex2000\Data` because the number of files in the idx's are small and don't contain any folders - just files.