### PR TITLE
pin frida to version. later versions are not working on windows 10 for some reason.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-frida
+frida==16.4.5
 requests


### PR DESCRIPTION
Experiencing an error when attaching to client. 

https://github.com/frida/frida-python/blob/7416839ae520f2c35f82d4aa90cbf819f91f0bc1/frida/__init__.py#L87-L95